### PR TITLE
Made functions in es_backed cache async and fixed bug with dedupe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Module to save state for teraslice processes.  Currently uses elasticsearch for 
   * __id_field__ - specifies the field to use as the key for caching and retrieving docs from elasticsearch  
   string, default: 'id'
   
-  * __persist__ - If set to true will save state in storage for set or mset.  
+  * __persist__ - If set to true will save state in storage for mset, doest not apply to set.  
   boolean, default: false
 
 ## Functions:

--- a/lib/cache-state-storage.js
+++ b/lib/cache-state-storage.js
@@ -44,6 +44,10 @@ class CacheStateStorage extends StateStorage {
     count() {
         return this.cache.itemCount;
     }
+
+    has(doc) {
+        return this.cache.has(doc[this.id_field]);
+    }
 }
 
 module.exports = CacheStateStorage;

--- a/lib/es-cache-state-storage.js
+++ b/lib/es-cache-state-storage.js
@@ -88,7 +88,7 @@ class EsCacheStateStorage extends CacheStateStorage {
 
 
     _dedupeDocs(docArray) {
-        // returns uniq keys from an array of docs
+        // returns uniq docs from an array of docs
         const uniqKeys = {};
         return docArray.filter((doc) => {
             const id = doc[this.id_field];
@@ -97,59 +97,47 @@ class EsCacheStateStorage extends CacheStateStorage {
         }, []);
     }
 
-    get(doc) {
-        return Promise.resolve()
-            .then(() => super.get(doc))
-            .then((state) => {
-                if (state) {
-                    return state;
-                }
-                return this._esGet(doc);
-            });
+    async get(doc) {
+        let cached = super.get(doc);
+        if (!cached) {
+            cached = await this._esGet(doc);
+        }
+        return cached;
     }
 
-    mget(docArray) {
+    async mget(docArray) {
         // dedupe docs
         const uniqDocs = this._dedupeDocs(docArray);
         const cachedDocs = super.mget(uniqDocs); // returns an object
         const nonCachedKeys = uniqDocs.filter(doc => !_.has(cachedDocs, doc[this.id_field]));
         // es search for keys not in cache
-        return Promise.map(_.chunk(nonCachedKeys, this.chunk_size),
-            chunk => this._esMget(chunk), { concurrency: this.concurrency })
-            .then(mgetResults => mgetResults.reduce((oneArray, item) => {
-                item.docs.forEach(doc => oneArray.push(doc));
-                return oneArray;
-            }, []))
-            .then((mgetArray) => {
-                // combine cached results with es results
-                mgetArray.forEach((item) => {
-                    if (item.found) {
-                        cachedDocs[item._id] = item._source;
-                    }
-                });
-                return cachedDocs;
+        const mgetResults = await Promise.map(_.chunk(nonCachedKeys, this.chunk_size),
+            chunk => this._esMget(chunk), { concurrency: this.concurrency });
+        // add es results data to cachedDocs
+        mgetResults.forEach((result) => {
+            // get the docs for each chunk returned
+            result.docs.forEach((doc) => {
+                if (doc.found) {
+                    cachedDocs[doc._id] = doc._source;
+                }
             });
+        });
+        return cachedDocs;
     }
 
-    set(doc) {
+    async set(doc) {
         if (this.persist) {
-            return Promise.all([
-                super.set(doc),
-                this._esUpdateOne(doc)
-            ]);
+            return Promise.all([super.set(doc), this._esUpdateOne(doc)]);
         }
-        return Promise.resolve(super.set(doc));
+        return super.set(doc);
     }
 
-    mset(docArray) {
+    async mset(docArray) {
         const dedupedDocs = this._dedupeDocs(docArray);
         if (this.persist) {
-            return Promise.all([
-                super.mset(dedupedDocs),
-                this._esBulkUpdate(dedupedDocs)
-            ]);
+            return Promise.all([super.mset(dedupedDocs), this._esBulkUpdate(dedupedDocs)]);
         }
-        return Promise.resolve(super.mset(dedupedDocs));
+        return super.mset(dedupedDocs);
     }
 }
 

--- a/lib/es-cache-state-storage.js
+++ b/lib/es-cache-state-storage.js
@@ -37,7 +37,6 @@ class EsCacheStateStorage extends CacheStateStorage {
             id: this.id_field,
             body: doc
         };
-
         return this.es.indexWithId(request);
     }
 
@@ -94,7 +93,7 @@ class EsCacheStateStorage extends CacheStateStorage {
             const id = doc[this.id_field];
             const uniq = _.has(uniqKeys, id) ? false : uniqKeys[id] = true;
             return uniq;
-        }, []);
+        });
     }
 
     async get(doc) {
@@ -109,7 +108,12 @@ class EsCacheStateStorage extends CacheStateStorage {
         // dedupe docs
         const uniqDocs = this._dedupeDocs(docArray);
         const cachedDocs = super.mget(uniqDocs); // returns an object
-        const nonCachedKeys = uniqDocs.filter(doc => !_.has(cachedDocs, doc[this.id_field]));
+        const nonCachedKeys = uniqDocs.reduce((keyArray, doc) => {
+            if (!_.has(cachedDocs, doc[this.id_field])) {
+                keyArray.push(doc[this.id_field]);
+            }
+            return keyArray;
+        }, []);
         // es search for keys not in cache
         const mgetResults = await Promise.map(_.chunk(nonCachedKeys, this.chunk_size),
             chunk => this._esMget(chunk), { concurrency: this.concurrency });
@@ -126,9 +130,6 @@ class EsCacheStateStorage extends CacheStateStorage {
     }
 
     async set(doc) {
-        if (this.persist) {
-            return Promise.all([super.set(doc), this._esUpdateOne(doc)]);
-        }
         return super.set(doc);
     }
 

--- a/spec/es-backed-state-storage-spec.js
+++ b/spec/es-backed-state-storage-spec.js
@@ -5,7 +5,6 @@ const StateStorage = require('../lib/es-cache-state-storage');
 
 let mgetData;
 let getData;
-let indexData;
 let bulkData;
 
 const context = {
@@ -13,11 +12,7 @@ const context = {
         apis: {
             elasticsearch: () => ({
                 mget: () => Promise.resolve(mgetData),
-                get: () => Promise.resolve(getData),
-                indexWithId: (request) => {
-                    indexData = request;
-                    return Promise.resolve();
-                }
+                get: () => Promise.resolve(getData)
             })
         },
         getConnection: () => ({
@@ -77,12 +72,11 @@ describe('es backed cache', () => {
         expect(stateStorage.count()).toBe(1);
     });
 
-    it('set should update storage for doc and persist doc if specified', () => {
+    it('set should update storage for doc no persistance for single doc', () => {
         config.persist = true;
         const stateStorage = new StateStorage(context, config);
         stateStorage.set(doc, true);
         expect(stateStorage.count()).toBe(1);
-        expect(indexData.body).toEqual({ id: 1, data: 'thisIsSomeData' });
     });
 
     it('mset should update storage for many docs and persist doc if specified', () => {


### PR DESCRIPTION
changed functions get, mset, get, met to async functions and found a bug with the doc dedupe function